### PR TITLE
Supprt sentry tags

### DIFF
--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -50,6 +50,9 @@ type tagsOption struct {
 }
 
 func (t tagsOption) apply(c *raven.Client) {
+	if c.Tags == nil {
+		c.Tags = make(map[string]string)
+	}
 	for k, v := range t.tags {
 		c.Tags[k] = v
 	}

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -2,19 +2,21 @@ package sentry
 
 import (
 	"context"
+	"runtime"
+	"strings"
+
 	"github.com/carousell/go-logging"
 	"github.com/carousell/go-notifier"
 	"github.com/getsentry/raven-go"
 	stdopentracing "github.com/opentracing/opentracing-go"
-	"runtime"
-	"strings"
 )
 
-func InitSentry(dsn string) (*sentryNotifier, error) {
+func InitSentry(dsn string, env string) (*sentryNotifier, error) {
 	client, err := raven.New(dsn)
 	if err != nil {
 		return nil, err
 	}
+	client.SetEnvironment(env)
 	return &sentryNotifier{
 		inited: true,
 		client: client,


### PR DESCRIPTION
The old Orion notifier [sets the environment tag](https://github.com/carousell/Orion/blob/master/utils/errors/notifier/notifier.go#L349) automatically according to Orion's env config. But this is missing in go-notifier. As a result, issues are reported without environment tag

<img width="1139" alt="image" src="https://github.com/user-attachments/assets/342ea287-a5d6-4336-8406-44bb366edd05" />


This PR adds the support for adding [Environment](https://github.com/getsentry/raven-go/blob/master/client.go#L535-L540) tag on the reported issue. As well as [Release](https://github.com/getsentry/raven-go/blob/master/client.go#L529-L533) tag and custom tags that supported natively by the Raven client.

The usage:

```golang
nf, err := sentry.InitSentry(cfg.Sentry.DSN, 
    sentry.WithEnvironment(cfg.Orion.Env), 
    sentry.WithRelease("1.2.3-achi"), 
    sentry.WithTags(map[string]string{
        "service": "delivery-manager"
    }
))
if err != nil {
    logging.Error(ctx, "msg", "Fail to init sentry", "err", err)
}
notifier.RegisterNotifier(nf)

notifier.Notify(errors.New("test notify with environment"), cfg.Orion, cfg.Sentry)
```

These adds more tags in the reported issues.

<img width="1224" alt="image" src="https://github.com/user-attachments/assets/fe59b24a-df36-43b9-ad05-701877ada876" />
